### PR TITLE
Extension: `incremental_drainage_area` addition

### DIFF
--- a/marquette/__main__.py
+++ b/marquette/__main__.py
@@ -84,6 +84,15 @@ def run_extensions(cfg, edges):
             log.info("global_dhbv_static_inputs already exists in zarr format")
         else:
             global_dhbv_static_inputs(cfg, edges)
+            
+    if "incremental_drainage_area" in cfg.extensions:
+        from marquette.merit.extensions import calculate_incremental_drainage_area
+
+        log.info("Adding edge/catchment area input data to your MERIT River Graph")
+        if "incremental_drainage_area" in edges:
+            log.info("incremental_drainage_area already exists in zarr format")
+        else:
+            calculate_incremental_drainage_area(cfg, edges)
 
 
 if __name__ == "__main__":

--- a/marquette/conf/config.yaml
+++ b/marquette/conf/config.yaml
@@ -17,9 +17,6 @@ create_N:
   obs_dataset_output: ${data_path}/gage_information/formatted_gage_csvs/gages_3000_merit_info.csv
   zone_obs_dataset: ${data_path}/gage_information/formatted_gage_csvs/${zone}.csv
 create_TMs:
-#  HUC:
-#    TM: ${data_path}/zarr/TMs/PFAF_${zone}
-#    shp_files: ${data_path}/huc_shp_files/huc_10_CONUS.shp
   MERIT:
     save_sparse: True
     TM: ${data_path}/zarr/TMs/MERIT_FLOWLINES_${zone}
@@ -35,6 +32,7 @@ extensions:
   - soils_data
   - pet_forcing
   - global_dhbv_static_inputs
+  - incremental_drainage_area
 # Hydra Config ------------------------------------------------------------------------#
 hydra:
   help:

--- a/marquette/merit/extensions.py
+++ b/marquette/merit/extensions.py
@@ -228,3 +228,46 @@ def global_dhbv_static_inputs(cfg: DictConfig, edges: zarr.Group) -> None:
     edges.array(name="mean_p", data=mean_p_arr[mapping])
     edges.array(name="mean_elevation", data=mean_elevation_arr[mapping])
     edges.array(name="glacier", data=glacier_arr[mapping])
+    
+    
+def calculate_incremental_drainage_area(cfg: DictConfig, edges: zarr.Group) -> None:
+    """
+    Runs a Polars query to calculate the incremental drainage area for each edge in the MERIT dataset
+    """   
+    basin_file = (
+        Path(cfg.data_path)
+        / f"raw/basins/cat_pfaf_{cfg.zone}_MERIT_Hydro_v07_Basins_v01_bugfix1.shp"
+    )
+    if basin_file.exists() is False:
+        raise FileNotFoundError("Basin file not found")
+    gdf = gpd.read_file(basin_file)
+    _df = pd.DataFrame(gdf.drop(columns="geometry"))
+    df = pl.from_pandas(_df)
+    edges_df = pl.DataFrame({"COMID": edges.merit_basin[:], "id": edges.id[:], "order": np.arange(edges.id.shape[0])})
+
+    result = df.lazy().join(
+        other=edges_df.lazy(),
+        left_on="COMID",
+        right_on="COMID",
+        how="left"
+    ).group_by(
+        by="COMID", 
+    ).agg([
+        pl.map_groups(
+            exprs=["unitarea", pl.first("unitarea")],
+            function=lambda list_of_series: 
+                list_of_series[1] / list_of_series[0].shape[0]
+        ).alias("incremental_drainage_area")
+    ]).join(
+        other=edges_df.lazy(),
+        left_on="COMID",
+        right_on="COMID",
+        how="left"
+    ).sort(
+        by="order"
+    ).collect()
+    edges.array(
+        name="incremental_drainage_area",
+        data=result.select(pl.col("incremental_drainage_area")).to_numpy().squeeze(),
+    )
+    


### PR DESCRIPTION
# Added:
- A function to create an `incremental_drainage_area` field for each edge
- The `incremental_drainage_area` is the area of the unit basin divided by the number of edges within that basin
- This is useful for reach-scale area calculations