### PR TITLE
added support for merit_conus_v3.0

### DIFF
--- a/marquette/__main__.py
+++ b/marquette/__main__.py
@@ -84,7 +84,7 @@ def run_extensions(cfg, edges):
             log.info("global_dhbv_static_inputs already exists in zarr format")
         else:
             global_dhbv_static_inputs(cfg, edges)
-            
+
     if "incremental_drainage_area" in cfg.extensions:
         from marquette.merit.extensions import calculate_incremental_drainage_area
 

--- a/marquette/conf/config.yaml
+++ b/marquette/conf/config.yaml
@@ -1,6 +1,6 @@
 name: MERIT
 data_path: /projects/mhpi/data/${name}
-zone: 75
+zone: 73
 create_edges:
   buffer: 0.3334
   dx: 2000
@@ -13,19 +13,19 @@ create_N:
   gage_buffered_flowline_intersections: ${data_path}/gage_information/gage_flowline_intersections/gage_9322_intersection.shp
   gage_coo_indices: ${data_path}/zarr/gage_coo_indices
   pad_gage_id: True
-  obs_dataset: ${data_path}/gage_information/obs_csvs/gages3000Info.csv
-  obs_dataset_output: ${data_path}/gage_information/formatted_gage_csvs/gages_3000_merit_info.csv
-  zone_obs_dataset: ${data_path}/gage_information/formatted_gage_csvs/${zone}.csv
+  obs_dataset: ${data_path}/gage_information/obs_csvs/all_gages_info.csv
+  obs_dataset_output: ${data_path}/gage_information/formatted_gage_csvs/all_gages_info_combined.csv
+  zone_obs_dataset: ${data_path}/gage_information/formatted_gage_csvs/${zone}_all.csv
 create_TMs:
   MERIT:
     save_sparse: True
     TM: ${data_path}/zarr/TMs/MERIT_FLOWLINES_${zone}
     shp_files: ${data_path}/raw/basins/cat_pfaf_${zone}_MERIT_Hydro_v07_Basins_v01_bugfix1.shp
 create_streamflow:
-  version: merit_conus_v1.1
+  version: merit_conus_v3.0
   data_store: ${data_path}/streamflow/zarr/${create_streamflow.version}/${zone}
   obs_attributes: ${data_path}/gage_information/MERIT_basin_area_info
-  predictions: /projects/mhpi/hjj5218/model_output/conus_zarr/${zone}
+  predictions: /projects/mhpi/yxs275/DM_output/dPL_local_daymet_new_attr_water_loss_v3_all_merit
   start_date: 01-01-1980
   end_date: 12-31-2020
 extensions:

--- a/marquette/merit/_connectivity_matrix.py
+++ b/marquette/merit/_connectivity_matrix.py
@@ -189,7 +189,7 @@ def map_gages_to_zone(cfg: DictConfig, edges: zarr.Group) -> gpd.GeoDataFrame:
 
     columns = [
         "STAID",
-        "STANAME",
+        # "STANAME",
         # "MERIT_ZONE",
         "HUC02",
         "DRAIN_SQKM",

--- a/marquette/merit/_streamflow_conversion_functions.py
+++ b/marquette/merit/_streamflow_conversion_functions.py
@@ -125,12 +125,16 @@ def calculate_merit_flow(cfg: DictConfig, edges: zarr.hierarchy.Group) -> None:
     streamflow_predictions_root = zarr.open(
         Path(cfg.create_streamflow.predictions), mode="r"
     )
-    
+
     # Different merit forwards have different save outputs. Specifying here to handle the different versions
-    version = int(cfg.create_streamflow.version.lower().split("_v")[1][0]) # getting the version number
+    version = int(
+        cfg.create_streamflow.version.lower().split("_v")[1][0]
+    )  # getting the version number
     if version >= 3:
         log.info(msg="Reading Zarr Store")
-        zone_keys = [key for key in streamflow_predictions_root.keys() if str(cfg.zone) in key]
+        zone_keys = [
+            key for key in streamflow_predictions_root.keys() if str(cfg.zone) in key
+        ]
         zone_comids = []
         zone_runoff = []
         for key in zone_keys:
@@ -140,7 +144,7 @@ def calculate_merit_flow(cfg: DictConfig, edges: zarr.hierarchy.Group) -> None:
         file_runoff = np.transpose(np.concatenate(zone_runoff))
         del zone_comids
         del zone_runoff
-    
+
     else:
         log.info("Reading Zarr Store")
         file_runoff = np.transpose(streamflow_predictions_root.Runoff)

--- a/marquette/merit/_streamflow_conversion_functions.py
+++ b/marquette/merit/_streamflow_conversion_functions.py
@@ -125,10 +125,27 @@ def calculate_merit_flow(cfg: DictConfig, edges: zarr.hierarchy.Group) -> None:
     streamflow_predictions_root = zarr.open(
         Path(cfg.create_streamflow.predictions), mode="r"
     )
-    log.info("Reading Zarr Store")
-    file_runoff = np.transpose(streamflow_predictions_root.Runoff)
+    
+    # Different merit forwards have different save outputs. Specifying here to handle the different versions
+    version = int(cfg.create_streamflow.version.lower().split("_v")[1][0]) # getting the version number
+    if version >= 3:
+        log.info(msg="Reading Zarr Store")
+        zone_keys = [key for key in streamflow_predictions_root.keys() if str(cfg.zone) in key]
+        zone_comids = []
+        zone_runoff = []
+        for key in zone_keys:
+            zone_comids.append(streamflow_predictions_root[key].COMID[:])
+            zone_runoff.append(streamflow_predictions_root[key].Qr[:])
+        streamflow_comids = np.concatenate(zone_comids).astype(int)
+        file_runoff = np.transpose(np.concatenate(zone_runoff))
+        del zone_comids
+        del zone_runoff
+    
+    else:
+        log.info("Reading Zarr Store")
+        file_runoff = np.transpose(streamflow_predictions_root.Runoff)
 
-    streamflow_comids: np.ndarray = streamflow_predictions_root.COMID[:].astype(int)
+        streamflow_comids: np.ndarray = streamflow_predictions_root.COMID[:].astype(int)
 
     log.info("Mapping predictions to zone COMIDs")
     runoff_full_zone = np.zeros((file_runoff.shape[0], edge_comids.shape[0]))


### PR DESCRIPTION
# Added:
- Added a version support for the latest merit conus data
```py
    # Different merit forwards have different save outputs. Specifying here to handle the different versions
    version = int(cfg.create_streamflow.version.lower().split("_v")[1][0]) # getting the version number
    if version >= 3:
        ...
    
    else:
        ...
```

This will make sure any properly versioned `merit_conus` or `merit_global` code is properly formatted